### PR TITLE
Add core models docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <b>Get
 involved: [Discord](https://link.maybe.co/discord) • [Website](https://maybefinance.com) • [Issues](https://github.com/maybe-finance/maybe/issues)</b>
 
-Maybe is an open-source personal finance application. You can deploy it yourself with Docker or use our managed hosting service. Learn how the pieces fit together in the [architecture overview](docs/architecture.md) and follow the [setup guide](docs/setup.md) to get started.
+Maybe is an open-source personal finance application. You can deploy it yourself with Docker or use our managed hosting service. Learn how the pieces fit together in the [architecture overview](docs/architecture.md) and the [core models guide](docs/core_models.md), and follow the [setup guide](docs/setup.md) to get started.
 
 ## Backstory
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,8 @@ choose which services to enable.
 - **Account** – represents a single financial account with balances and entries
 - **Transaction** – entry that tracks income or spending on an account
 - **Budget** – monthly budget with categories and allocations
+See [core models guide](core_models.md) for relationships and key methods.
+
 
 Refer to `db/schema.rb` for the full relationships.
 

--- a/docs/core_models.md
+++ b/docs/core_models.md
@@ -1,0 +1,69 @@
+# Core Models
+
+This document highlights the main domain models used throughout the application and how they relate to one another.
+
+## Family
+
+*Top level entity that owns accounts, users and data.*
+
+**Associations**
+
+- `has_many :users`
+- `has_many :accounts`
+- `has_many :budgets`
+- `has_many :categories`
+- `has_many :transactions, through: :accounts`
+
+**Notable methods**
+
+- `syncing?` – checks if any accounts or items are currently syncing.
+
+## Account
+
+*Represents a financial account such as a bank or brokerage account.*
+
+**Associations**
+
+- `belongs_to :family`
+- `has_many :entries`
+- `has_many :transactions, through: :entries`
+- `has_many :balances`
+
+**Notable methods**
+
+- `self.create_and_sync` – builds an account with initial balance entries and immediately queues a sync job.
+
+## Transaction
+
+*Represents a single inflow or outflow on an account.*
+
+**Associations**
+
+- `belongs_to :category`
+- `belongs_to :merchant`
+- `has_one :entry` (via `Entryable`)
+- `has_many :tags` (through taggings)
+
+**Notable methods**
+
+- `Transaction::Search` – utility object that builds an ActiveRecord query from search parameters.
+
+## Budget
+
+*Monthly budget for a family.*
+
+**Associations**
+
+- `belongs_to :family`
+- `has_many :budget_categories`
+
+**Notable methods**
+
+- `sync_budget_categories` – ensures the budget has a category for each of the family’s expense categories.
+
+## Typical Workflow
+
+1. **Create a Family** – a user signs up and a `Family` record is created.
+2. **Add Accounts** – accounts are added using `Account.create_and_sync`, which seeds initial balance entries and begins a sync with any connected provider.
+3. **Record Transactions** – transactions arrive via account syncs or manual entry. They can be searched using `Transaction::Search` and categorized as needed.
+4. **Manage Budgets** – each month a `Budget` is created (often via `Budget.find_or_bootstrap`). `sync_budget_categories` keeps its categories in sync with the family’s list so spending can be tracked against budgeted amounts.


### PR DESCRIPTION
## Summary
- create documentation covering core domain models
- link the guide from the README and architecture overview

## Testing
- `bin/rubocop -f github` *(fails: `bundle install` needed)*
- `bin/rails test` *(fails: `bundle install` needed)*

------
https://chatgpt.com/codex/tasks/task_e_684d290dfea8833181f12e0a5c8b173e